### PR TITLE
Issues/12: Use score image to do detection

### DIFF
--- a/changes/24.feature.rst
+++ b/changes/24.feature.rst
@@ -1,0 +1,1 @@
+Create detection catalog based on SFFT Score image.

--- a/detect_supernova/pipeline.py
+++ b/detect_supernova/pipeline.py
@@ -285,8 +285,8 @@ class Detection:
             file_path["difference_image_path"],
             file_path["score_image_detection_path"],
             self.MATCH_RADIUS,
-            file_path["transients_to_score_image_detection_path"],
-            file_path["score_image_detection_to_transients_path"],
+            file_path["transients_to_score_detection_path"],
+            file_path["score_detection_to_transients_path"],
         )
 
         print("[INFO] Processing finished.")

--- a/detect_supernova/pipeline.py
+++ b/detect_supernova/pipeline.py
@@ -44,9 +44,7 @@ class Detection:
         + "/RomanTDS/truth/{band}/{pointing}/Roman_TDS_index_{band}_{pointing}_{sca}.txt"
     )
 
-    DIFF_PATTERN = (
-        "{science_band}_{science_pointing}_{science_sca}_-_{template_band}_{template_pointing}_{template_sca}"
-    )
+    DIFF_PATTERN = "{science_band}_{science_pointing}_{science_sca}_-_{template_band}_{template_pointing}_{template_sca}"
 
     # Source detection config.
     SOURCE_EXTRACTOR_EXECUTABLE = "source-extractor"
@@ -65,10 +63,14 @@ class Detection:
 
     # file prefix
     DIFF_IMAGE_PREFIX = "decorr_diff_"
+    DIFF_SCORE_PREFIX = "score_"
     DIFF_DETECTION_PREFIX = "detection_"
+    DIFF_SCORE_DETECTION_PREFIX = "score_detection_"
     DIFF_TRUTH_PREFIX = "truth_"
     TRANSIENTS_TO_DETECTION_PREFIX = "transients_to_detection_"
     DETECTION_TO_TRANSIENTS_PREFIX = "detection_to_transients_"
+    TRANSIENTS_TO_SCORE_DETECTION_PREFIX = "transients_to_score_detection_"
+    SCORE_DETECTION_TO_TRANSIENTS_PREFIX = "score_detection_to_transients_"
 
     def __init__(self, data_records_path, temp_dir=None, output_dir="./output"):
         self.data_records_path = data_records_path
@@ -157,6 +159,20 @@ class Detection:
             file_path["full_output_dir"],
             self.DIFF_DETECTION_PREFIX + diff_pattern + ".cat",
         )
+        file_path["score_image_path"] = os.path.join(
+            file_path["full_output_dir"],
+            self.DIFF_SCORE_PREFIX + diff_pattern + ".fits",
+        )
+        # diff score image detection
+        file_path["score_image_detection_path"] = os.path.join(
+            file_path["full_output_dir"],
+            self.SCORE_DETECTION_PREFIX + diff_pattern + ".ecsv",
+        )
+        # decorr diff image detection
+        file_path["difference_detection_path"] = os.path.join(
+            file_path["full_output_dir"],
+            self.DIFF_DETECTION_PREFIX + diff_pattern + ".cat",
+        )
         # truth retrieval
         file_path["science_truth_path"] = self.INPUT_TRUTH_PATTERN.format(**science_id)
         file_path["template_truth_path"] = self.INPUT_TRUTH_PATTERN.format(
@@ -174,6 +190,14 @@ class Detection:
         file_path["detection_to_transients_path"] = os.path.join(
             file_path["full_output_dir"],
             self.DETECTION_TO_TRANSIENTS_PREFIX + diff_pattern + ".csv",
+        )
+        file_path["transients_to_score_detection_path"] = os.path.join(
+            file_path["full_output_dir"],
+            self.TRANSIENTS_TO_SCORE_DETECTION_PREFIX + diff_pattern + ".csv",
+        )
+        file_path["score_detection_to_transients_path"] = os.path.join(
+            file_path["full_output_dir"],
+            self.SCORE_DETECTION_TO_TRANSIENTS_PREFIX + diff_pattern + ".csv",
         )
         return file_path
 
@@ -243,16 +267,24 @@ class Detection:
             file_path["difference_truth_path"],
         )
 
-        print("[INFO] Processing truth matching")
-        _, _ = (
-            self.__class__.match_transients(
-                truth,
-                file_path["difference_image_path"],
-                file_path["difference_detection_path"],
-                self.MATCH_RADIUS,
-                file_path["transients_to_detection_path"],
-                file_path["detection_to_transients_path"],
-            )
+        print("[INFO] Processing diffim detection truth matching")
+        _, _ = self.__class__.match_transients(
+            truth,
+            file_path["difference_image_path"],
+            file_path["difference_detection_path"],
+            self.MATCH_RADIUS,
+            file_path["transients_to_detection_path"],
+            file_path["detection_to_transients_path"],
+        )
+
+        print("[INFO] Processing score image detection truth matching")
+        _, _ = self.__class__.match_transients(
+            truth,
+            file_path["difference_image_path"],
+            file_path["score_image_detection_path"],
+            self.MATCH_RADIUS,
+            file_path["transients_to_score_image_detection_path"],
+            file_path["score_image_detection_to_transients_path"],
         )
 
         print("[INFO] Processing finished.")

--- a/detect_supernova/pipeline.py
+++ b/detect_supernova/pipeline.py
@@ -228,6 +228,12 @@ class Detection:
             detection_filter=self.DETECTION_FILTER,
         )
 
+        print("[INFO] Processing score image detection")
+        source_detection.score_image_detect(
+                                            file_path["score_image_path"],
+                                            file_path["score_image_detection_path"],
+                                            )
+
         print("[INFO] Processing truth retrieval")
         truth = self.__class__.retrieve_truth(
             file_path["science_image_path"],

--- a/detect_supernova/pipeline.py
+++ b/detect_supernova/pipeline.py
@@ -114,6 +114,30 @@ class Detection:
         x_col="X_IMAGE",
         y_col="Y_IMAGE",
     ):
+        """Match a truth catalog to subtraction detection catalogs
+
+        Parameter
+        ---------
+        truth : pandas dataframe
+        difference_image_path : str
+        difference_detection_path : str
+        match_radius : float
+            Match radius in arcseconds
+        transients_to_detection_path : str
+        detection_to_transients_path : str
+        transient_frame : str
+            AstroPy coordinate frame.  E.g., "icrs" or "fk5"
+        x_col : str
+            Name of column in detection table for x coordinate
+        y_col
+            Name of column in detection table for y coordinate
+
+        Return
+        ------
+        (astropy.table.Table, astropy.table.Table) :
+            truth matched to detections,
+            detections matched to truth
+        """
         difference_wcs = data_loader.load_wcs(difference_image_path, hdu_id=0)
 
         detection = data_loader.load_table(difference_detection_path)

--- a/detect_supernova/pipeline.py
+++ b/detect_supernova/pipeline.py
@@ -44,7 +44,9 @@ class Detection:
         + "/RomanTDS/truth/{band}/{pointing}/Roman_TDS_index_{band}_{pointing}_{sca}.txt"
     )
 
-    DIFF_PATTERN = "{science_band}_{science_pointing}_{science_sca}_-_{template_band}_{template_pointing}_{template_sca}"
+    DIFF_PATTERN = (
+        "{science_band}_{science_pointing}_{science_sca}_-_{template_band}_{template_pointing}_{template_sca}"
+    )
 
     # Source detection config.
     SOURCE_EXTRACTOR_EXECUTABLE = "source-extractor"
@@ -65,7 +67,7 @@ class Detection:
     DIFF_IMAGE_PREFIX = "decorr_diff_"
     DIFF_SCORE_PREFIX = "score_"
     DIFF_DETECTION_PREFIX = "detection_"
-    DIFF_SCORE_DETECTION_PREFIX = "score_detection_"
+    SCORE_DETECTION_PREFIX = "score_detection_"
     DIFF_TRUTH_PREFIX = "truth_"
     TRANSIENTS_TO_DETECTION_PREFIX = "transients_to_detection_"
     DETECTION_TO_TRANSIENTS_PREFIX = "detection_to_transients_"

--- a/detect_supernova/pipeline.py
+++ b/detect_supernova/pipeline.py
@@ -110,16 +110,19 @@ class Detection:
         match_radius,
         transients_to_detection_path,
         detection_to_transients_path,
+        transient_frame="icrs",
+        x_col="X_IMAGE",
+        y_col="Y_IMAGE",
     ):
         difference_wcs = data_loader.load_wcs(difference_image_path, hdu_id=0)
 
         detection = data_loader.load_table(difference_detection_path)
         transients = truth[truth.obj_type == "transient"].copy().reset_index(drop=True)
         transients_skycoord = SkyCoord(
-            transients.ra, transients.dec, frame="icrs", unit="deg"
+            transients.ra, transients.dec, frame=transient_frame, unit="deg"
         )
         detection_skycoord = pixel_to_skycoord(
-            detection.X_IMAGE, detection.Y_IMAGE, difference_wcs
+            detection[x_col], detection[y_col], difference_wcs
         )
         transients_to_detection = truth_matching.skymatch_and_join(
             transients, detection, transients_skycoord, detection_skycoord, match_radius
@@ -277,6 +280,8 @@ class Detection:
             self.MATCH_RADIUS,
             file_path["transients_to_detection_path"],
             file_path["detection_to_transients_path"],
+            x_col="X_IMAGE",
+            y_col="Y_IMAGE",
         )
 
         print("[INFO] Processing score image detection truth matching")
@@ -287,6 +292,8 @@ class Detection:
             self.MATCH_RADIUS,
             file_path["transients_to_score_detection_path"],
             file_path["score_detection_to_transients_path"],
+            x_col="x_peak",
+            y_col="y_peak",
         )
 
         print("[INFO] Processing finished.")

--- a/detect_supernova/pipeline.py
+++ b/detect_supernova/pipeline.py
@@ -230,9 +230,9 @@ class Detection:
 
         print("[INFO] Processing score image detection")
         source_detection.score_image_detect(
-                                            file_path["score_image_path"],
-                                            file_path["score_image_detection_path"],
-                                            )
+            file_path["score_image_path"],
+            file_path["score_image_detection_path"],
+        )
 
         print("[INFO] Processing truth retrieval")
         truth = self.__class__.retrieve_truth(

--- a/detect_supernova/source_detection.py
+++ b/detect_supernova/source_detection.py
@@ -2,6 +2,7 @@ import subprocess
 
 from astropy.io import fits
 from astropy.table import vstack
+from photutils.centroids import centroid_com
 from photutils.detection import find_peaks
 
 SOURCE_EXTRACTOR_EXECUTABLE = "source-extractor"
@@ -77,8 +78,9 @@ def score_image_detect(
     https://photutils.readthedocs.io/en/stable/user_guide/detection.html
     """
     image = fits.getdata(score_image_path)
-    pos_obj = find_peaks(image, threshold=threshold, box_size=box_size)
-    neg_obj = find_peaks(-image, threshold=threshold, box_size=box_size)
+    find_peaks_kwargs = {"threshold": threshold, "box_size": box_size, "centroid_func": centroid_com}
+    pos_obj = find_peaks(image, **find_peaks_kwargs)
+    neg_obj = find_peaks(-image, **find_peaks_kwargs)
     neg_obj["peak_value"] = -neg_obj["peak_value"]
 
     obj = vstack([pos_obj, neg_obj])

--- a/detect_supernova/source_detection.py
+++ b/detect_supernova/source_detection.py
@@ -42,7 +42,7 @@ def detect(
 
 
 def score_image_detect(
-    score_image_path, catalog_save_path=None, threshold=10, box_size=11, negative=True
+    score_image_path, catalog_save_path=None, threshold=10, box_size=11, negative=True, overwrite=True,
 ):
     """Detect based on the peak pixels in the score image.
 
@@ -56,6 +56,8 @@ def score_image_detect(
         Size of box in which to look for unique peaks.  Passed to photutils.find_peaks.
     negative : bool
         Search for negative sources as well as positive sources.
+    overwrite : bool
+        Overwrite existing catalog_save_path
 
     Returns
     -------
@@ -82,6 +84,6 @@ def score_image_detect(
     obj = vstack([pos_obj, neg_obj])
 
     if catalog_save_path is not None:
-        obj.write(catalog_save_path)
+        obj.write(catalog_save_path, overwrite=overwrite)
 
     return obj

--- a/detect_supernova/source_detection.py
+++ b/detect_supernova/source_detection.py
@@ -44,8 +44,7 @@ def detect(
 def score_image_detect(
     score_image_path, catalog_save_path=None, threshold=10, box_size=11, negative=True
 ):
-    """
-    Detect based on the peak pixels in the score image.
+    """Detect based on the peak pixels in the score image.
 
     Parameters
     ----------

--- a/detect_supernova/source_detection.py
+++ b/detect_supernova/source_detection.py
@@ -35,3 +35,13 @@ def detect(
     result = subprocess.run(detection_cmd, capture_output=True, text=True)
 
     return result
+
+def score_image_detect()
+    """
+    Detect based on a score image.  Peak pixels.
+
+    This is equivalent to doing PSF convolution on a direct image and looking for peaks.
+
+    Use astropy.photutils
+    """
+    pass

--- a/detect_supernova/source_detection.py
+++ b/detect_supernova/source_detection.py
@@ -79,7 +79,7 @@ def score_image_detect(
     neg_obj = find_peaks(-image, threshold=threshold, box_size=box_size)
     neg_obj["peak_value"] = -neg_obj["peak_value"]
 
-    obj = vstack(pos_obj, neg_obj)
+    obj = vstack([pos_obj, neg_obj])
 
     if catalog_save_path is not None:
         obj.write(catalog_save_path)

--- a/detect_supernova/source_detection.py
+++ b/detect_supernova/source_detection.py
@@ -66,11 +66,13 @@ def score_image_detect(
 
     Notes
     -----
-    This is equivalent to doing PSF convolution on a direct image,
-    dividing by the variance, and looking for significant peaks.
+    The score image for a subtraction is the equivalent of cross-correlating a
+    direct image with its PSF and dividing by the variance.  We then look for
+    for significant peaks to identiy sources.
 
     The searches for positive and negative sources run separately,
-    and thus a positive source and a negative source can be found within the same box_size region.
+    and thus a positive source and a negative source can be found within the
+    same box_size region.
 
     Uses astropy.photutils
 

--- a/detect_supernova/source_detection.py
+++ b/detect_supernova/source_detection.py
@@ -41,13 +41,36 @@ def detect(
     return result
 
 
-def score_image_detect(score_image_path, catalog_save_path=None, threshold=10, box_size=11):
+def score_image_detect(
+    score_image_path, catalog_save_path=None, threshold=10, box_size=11, negative=True
+):
     """
     Detect based on the peak pixels in the score image.
 
-    This is equivalent to doing PSF convolution on a direct image and looking for peaks.
+    Parameters
+    ----------
+    score_image_path : str
+        Path to score image
+    threshold : float
+        Signal-to-noise ratio threshold.
+    box_size : int
+        Size of box in which to look for unique peaks.  Passed to photutils.find_peaks.
+    negative : bool
+        Search for negative sources as well as positive sources.
 
-    Use astropy.photutils
+    Returns
+    -------
+    AstroPy Table of results
+
+    Notes
+    -----
+    This is equivalent to doing PSF convolution on a direct image,
+    dividing by the variance, and looking for significant peaks.
+
+    The searches for positive and negative sources run separately,
+    and thus a positive source and a negative source can be found within the same box_size region.
+
+    Uses astropy.photutils
 
     Based on
     https://photutils.readthedocs.io/en/stable/user_guide/detection.html
@@ -55,7 +78,7 @@ def score_image_detect(score_image_path, catalog_save_path=None, threshold=10, b
     image = fits.getdata(score_image_path)
     pos_obj = find_peaks(image, threshold=threshold, box_size=box_size)
     neg_obj = find_peaks(-image, threshold=threshold, box_size=box_size)
-    neg_obj["peak_value"] = - neg_obj["peak_value"]
+    neg_obj["peak_value"] = -neg_obj["peak_value"]
 
     obj = vstack(pos_obj, neg_obj)
 

--- a/detect_supernova/subtraction.py
+++ b/detect_supernova/subtraction.py
@@ -284,7 +284,7 @@ class Pipeline:
         # because the create_score_image uses FKDECO_GPU
         # which is calculated in find_decorrelation
         # and saved as attribute of instance
-        sfftifier.create_score_image()
+        score_image = sfftifier.create_score_image()
 
         # run decorrelation
         decorr_diff = sfftifier.apply_decorrelation(sfftifier.PixA_DIFF_GPU)
@@ -294,7 +294,7 @@ class Pipeline:
         # save data products
         fits.writeto(
             self.score_image_path,
-            cp.asnumpy(),
+            cp.asnumpy(score_image),
             header=sfftifier.hdr_target,
             overwrite=True,
         )

--- a/detect_supernova/subtraction.py
+++ b/detect_supernova/subtraction.py
@@ -294,7 +294,7 @@ class Pipeline:
         # save data products
         fits.writeto(
             self.score_image_path,
-            cp.asnumpy(score_image),
+            cp.asnumpy(score_image).T,
             header=sfftifier.hdr_target,
             overwrite=True,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,9 @@ dependencies = [
   "coverage",
   "numpy",
   "astropy>=3.2",
+  "photutils",
   "snpit_utils",
-  "sfft-romansnpit",
+  "sfft-romansnpit>1.6.4.dev6",
   "sep",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "astropy>=3.2",
   "photutils",
   "snpit_utils",
-  "sfft-romansnpit>1.6.4.dev6",
+  "sfft-romansnpit>=1.6.4.dev6",
   "sep",
 ]
 


### PR DESCRIPTION
Uses the score image from SFFT to do detection and centroiding.
Matches score image detection catalog to truth (in same manner as diffim detection catalog is matched).

Closes #12 

Does not do photometry at score image locations.  The right way is to do photometry on the (decorrelated?) difference image.  That will be #23 