### PR TITLE
Add black line length specification.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,9 @@ exclude_lines = [
   "@overload",
 ]
 
+[tool.black]
+line-length = 120
+
 [tool.ruff]
 line-length = 120
 indent-width = 4


### PR DESCRIPTION
Very simple change.  Add line-length to pyproject.toml so running black within the repo will pick up this line-length.