### PR TITLE
U/wmwv/ricksims2

### DIFF
--- a/changes/71.feature.rst
+++ b/changes/71.feature.rst
@@ -1,0 +1,1 @@
+Update to run on version 2 of Ricksims.  These updates include both general improvements, and a specific observation_id hack for images that don't have one defined (or have it defined as "?").

--- a/examples/smdc/test_RomanDatamodelImage_id_sca_band.py
+++ b/examples/smdc/test_RomanDatamodelImage_id_sca_band.py
@@ -1,3 +1,9 @@
+"""
+Test that we can read band, observation_id, sca from a particular RomandDatamodelImage
+
+You can check this by using less/more/cat/grep to just read the plain text of the ASDF header.
+"""
+
 from pathlib import Path
 
 from snappl.image import RomanDatamodelImage
@@ -7,5 +13,8 @@ science_image = Path("SNPIT_VISIT602000033_WFI01_F106_L2.asdf")
 
 science_image_path = base_path / science_image
 
-image = RomanDatamodelImage(full_filepath = science_image_path, no_base_path=True)
+science_image = RomanDatamodelImage(full_filepath = science_image_path, no_base_path=True)
 
+print(science_image.band)
+print(science_image.observation_id)
+print(science_image.sca)

--- a/examples/smdc/test_RomanDatamodelImage_id_sca_band.py
+++ b/examples/smdc/test_RomanDatamodelImage_id_sca_band.py
@@ -1,5 +1,4 @@
-"""
-Test that we can read band, observation_id, sca from a particular RomandDatamodelImage
+"""Test that we can read band, observation_id, sca from a particular RomandDatamodelImage
 
 You can check this by using less/more/cat/grep to just read the plain text of the ASDF header.
 """

--- a/examples/smdc/test_RomanDatamodelImage_id_sca_band.py
+++ b/examples/smdc/test_RomanDatamodelImage_id_sca_band.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from snappl.image import RomanDatamodelImage
+
+base_path = Path("/mnt/roman-science-east-2/snpit/snana+romanisim+romancal/output_images_SCAx2_ZYJHF_40day/")
+science_image = Path("SNPIT_VISIT602000033_WFI01_F106_L2.asdf")
+
+science_image_path = base_path / science_image
+
+image = RomanDatamodelImage(full_filepath = science_image_path, no_base_path=True)
+

--- a/examples/smdc/test_sidecar_asdf_kesslersim_v2.sh
+++ b/examples/smdc/test_sidecar_asdf_kesslersim_v2.sh
@@ -1,0 +1,23 @@
+# cd ${HOME}/Roman/pipeline/snappl; pip install -e .
+# cd ${HOME}/Roman/pipeline/sfft; pip install -e .
+# cd ${HOME}/Roman/pipeline/sidecar; pip install -e . --no-deps
+# cd ${HOME}/Roman/pipeline
+
+export SNPIT_DEFAULT_CONFIG=${HOME}/Roman/pipeline/environment/smdc_interactive_config.yaml
+export SNPIT_CONFIG=${SNPIT_DEFAULT_CONFIG}
+
+base_path=/mnt/roman-science-east-2/snpit/snana+romanisim+romancal/output_images_SCAx2_ZYJHF_40day/
+
+template_path=${base_path}/SNPIT_VISIT602000033_WFI01_F106_L2.asdf
+science_path=${base_path}/SNPIT_VISIT607000033_WFI01_F106_L2.asdf
+python -m pdb \
+    sidecar/sidecar/pipeline.py \
+    --image-collection manual_rdm \
+    --base-path ${base_path} \
+    --template-path ${template_path} \
+    --science-path ${science_path} \
+    --no-reject-known-stars \
+    --temp-dir ${HOME}/tmp \
+    --output-dir ./ \
+    --save-debug-products \
+    --backend4subtract numpy

--- a/sidecar/subtraction.py
+++ b/sidecar/subtraction.py
@@ -314,6 +314,20 @@ class Pipeline:
                 **{"band": template_band, "observation_id": template_observation_id, "sca": template_sca},
             )
 
+        # Mild hack/potentially unexpected, if you set observation_id, band, it will overwride
+        if science_band is not None:
+            self.science_image.band = science_band
+        if science_observation_id is not None:
+            self.science_image.observation_id = science_observation_id
+        if science_sca is not None:
+            self.science_image.sca = science_sca
+        if template_band is not None:
+            self.template_image.band = template_band
+        if template_observation_id is not None:
+            self.template_image.observation_id = template_observation_id
+        if template_sca is not None:
+            self.template_image.sca = template_sca
+
         self.diff_pattern = (
             f"{self.science_image.band}_{self.science_image.observation_id}_{self.science_image.sca}"
             f"_-_{self.template_image.band}_{self.template_image.observation_id}_{self.template_image.sca}"

--- a/sidecar/subtraction.py
+++ b/sidecar/subtraction.py
@@ -366,8 +366,12 @@ class Pipeline:
         self.template_image._data, template_image_interpolated_mask = interpolate_over_bad_pixels(
             self.template_image.data, self.template_image.flags, bad_pixel_flags=bad_pixel_flags
         )
-        science_noise, _ = interpolate_over_bad_pixels(self.science_image.noise, self.science_image.flags, bad_pixel_flags=bad_pixel_flags)
-        template_noise, _ = interpolate_over_bad_pixels(self.template_image.noise, self.template_image.flags, bad_pixel_flags=bad_pixel_flags)
+        science_noise, _ = interpolate_over_bad_pixels(
+            self.science_image.noise, self.science_image.flags, bad_pixel_flags=bad_pixel_flags
+        )
+        template_noise, _ = interpolate_over_bad_pixels(
+            self.template_image.noise, self.template_image.flags, bad_pixel_flags=bad_pixel_flags
+        )
 
         # sky subtraction and source detection
         science_skysubim_data, science_detmask_data, science_skyrms = sky_subtract_and_detect(self.science_image)

--- a/sidecar/subtraction.py
+++ b/sidecar/subtraction.py
@@ -314,19 +314,13 @@ class Pipeline:
                 **{"band": template_band, "observation_id": template_observation_id, "sca": template_sca},
             )
 
-        # Mild hack/potentially unexpected, if you set observation_id, band, it will overwride
-        if science_band is not None:
-            self.science_image.band = science_band
+        # Mild hack/potentially unexpected, if you set observation_id, it will override
+        # This is needed because as of 2026-07-23, the sims the SN PIT is generating
+        # don't have an observation_id set.
         if science_observation_id is not None:
             self.science_image.observation_id = science_observation_id
-        if science_sca is not None:
-            self.science_image.sca = science_sca
-        if template_band is not None:
-            self.template_image.band = template_band
         if template_observation_id is not None:
             self.template_image.observation_id = template_observation_id
-        if template_sca is not None:
-            self.template_image.sca = template_sca
 
         self.diff_pattern = (
             f"{self.science_image.band}_{self.science_image.observation_id}_{self.science_image.sca}"

--- a/sidecar/subtraction.py
+++ b/sidecar/subtraction.py
@@ -23,17 +23,17 @@ from snappl.psf import PSF
 bad_pixel_flags = 2 ** len(dqflags.pixel) - 1 - dqflags.pixel.WARM - dqflags.pixel.LOW_QE
 
 
-def interpolate_over_bad_pixels(image, bad_pixel_flags=bad_pixel_flags, fill_value=0):
+def interpolate_over_bad_pixels(data, flags, bad_pixel_flags=bad_pixel_flags):
     """Interpolate over bad pixels in an image.
 
     Parameters
     ----------
-    image : object
-        Input image object containing `data` and `flags` arrays.
+    data : ndarray
+        Input image data.
+    flags : ndarray
+        Image flags indicating bad pixels.
     bad_pixel_flags : int, optional
         Bitwise combination of DQ flags used to identify bad pixels.
-    fill_value : float, optional
-        Value to use for filling bad pixels if interpolation is not possible. Default is 0.
 
     Returns
     -------
@@ -51,16 +51,16 @@ def interpolate_over_bad_pixels(image, bad_pixel_flags=bad_pixel_flags, fill_val
     (e.g., using neighboring pixel values), depending on the implementation.
     """
     # Create a mask of bad pixels based on the flags
-    bad_mask = image.flags & bad_pixel_flags > 0
+    bad_mask = flags & bad_pixel_flags > 0
 
-    interpolated_data = image.data.copy()
+    interpolated_data = data.copy()
     interpolated_data[bad_mask] = np.nan  # Mark bad pixels as NaN for interpolation
 
     # Example interpolation using nearest neighbor
-    x, y = np.indices(image.data.shape)
+    x, y = np.indices(data.shape)
     good_pixels = ~bad_mask
     interpolated_data[bad_mask] = griddata(
-        (x[good_pixels], y[good_pixels]), image.data[good_pixels], (x[bad_mask], y[bad_mask]), method="nearest"
+        (x[good_pixels], y[good_pixels]), data[good_pixels], (x[bad_mask], y[bad_mask]), method="nearest"
     )
 
     return interpolated_data, bad_mask
@@ -204,13 +204,37 @@ def make_minimal_wcs_header(image):
 
 
 def _save_products_as_fits(path, hdr, data, noise, flags, mask):
+    """Save products as a FITS file with multiple HDUs.
+
+    data: 2D ndarray
+        2D array of the image data
+    noise: 2D ndarray
+        2D array of the noise data.
+        Will check to see if this is a 16-bit float array, and if so promote to 32-bit float.
+        Will otherwise leave alone, so 32-bit or 64-bit float arrays will be kept,
+        but also 16-bit int or 32-bit int will be saved as is.
+    flags: 2D ndarray of the flags data
+    mask: 2D ndarray of the detection mask
+        Written as uint8 array
+    """
+
+    # Handle types.  Make copies if we change something, so we don't modify the passed-in array
+    # but views if we don't modify are fine.
+    # Noise array from romancal L2 is 16-bit float so let's check for that and recast to 32-bit float
+    if noise.dtype == np.float16:
+        noise_standardized = noise.astype(np.float32)
+    else:
+        noise_standardized = noise
+    # Make sure the mask is interpreted as an unsigned 8-bit integer array
+    mask_standardized = mask.astype(np.uint8)
+
     hdul = fits.HDUList(
         [
             fits.PrimaryHDU(data=None, header=hdr),
             fits.ImageHDU(data=data, name="DATA", header=hdr),
-            fits.ImageHDU(data=noise, name="NOISE", header=hdr),
+            fits.ImageHDU(data=noise_standardized, name="NOISE", header=hdr),
             fits.ImageHDU(data=flags, name="FLAGS", header=hdr),
-            fits.ImageHDU(data=np.asarray(mask, dtype="uint8"), name="MASK", header=hdr),
+            fits.ImageHDU(data=mask_standardized, name="MASK", header=hdr),
         ]
     )
     hdul.writeto(path, overwrite=True)
@@ -329,11 +353,13 @@ class Pipeline:
         # Interpolate over bad pixels in the science and template images before sky subtraction and source detection.
         # This is to avoid bad pixels in the images being convolved out to look like sources
         self.science_image._data, science_image_interpolated_mask = interpolate_over_bad_pixels(
-            self.science_image, bad_pixel_flags=bad_pixel_flags
+            self.science_image.data, self.science_image.flags, bad_pixel_flags=bad_pixel_flags
         )
         self.template_image._data, template_image_interpolated_mask = interpolate_over_bad_pixels(
-            self.template_image, bad_pixel_flags=bad_pixel_flags
+            self.template_image.data, self.template_image.flags, bad_pixel_flags=bad_pixel_flags
         )
+        science_noise, _ = interpolate_over_bad_pixels(self.science_image.noise, self.science_image.flags, bad_pixel_flags=bad_pixel_flags)
+        template_noise, _ = interpolate_over_bad_pixels(self.template_image.noise, self.template_image.flags, bad_pixel_flags=bad_pixel_flags)
 
         # sky subtraction and source detection
         science_skysubim_data, science_detmask_data, science_skyrms = sky_subtract_and_detect(self.science_image)
@@ -348,7 +374,7 @@ class Pipeline:
                 path=self.science_debug_path,
                 hdr=science_hdr,
                 data=science_skysubim_data,
-                noise=self.science_image.noise,
+                noise=science_noise,
                 flags=self.science_image.flags,
                 mask=science_detmask_data,
             )
@@ -356,7 +382,7 @@ class Pipeline:
                 path=self.template_debug_path,
                 hdr=template_hdr,
                 data=template_skysubim_data,
-                noise=self.template_image.noise,
+                noise=template_noise,
                 flags=self.template_image.flags,
                 mask=template_detmask_data,
             )
@@ -368,8 +394,8 @@ class Pipeline:
             template_skyrms,
             science_skysubim_data,
             template_skysubim_data,
-            self.science_image.noise,
-            self.template_image.noise,
+            science_noise,
+            template_noise,
             science_detmask_data,
             template_detmask_data,
             science_psf,

--- a/sidecar/util.py
+++ b/sidecar/util.py
@@ -349,6 +349,8 @@ def get_observation_id_sca_band_from_image_path(image_path):
     ('52395', 3, 'R062')
     >>> get_observation_id_sca_band_from_image_path("r9999901001001001001_0001_wfi01_f158_cal.asdf")
     ('99999010010010010010001', 1, 'F158')
+    >>> get_observation_id_sca_band_from_image_path("SNPIT_VISIT602000033_WFI01_F106_L2.asdf")
+    ('602000033', 1, 'F106')
 
     The output strings are listed with single-quotes because that's what doctest is going to get.
     """
@@ -365,6 +367,11 @@ def get_observation_id_sca_band_from_image_path(image_path):
         # RomanTDS simulated catalog / ASDF naming convention.
         re.compile(
             r"[rR]?(?P<observation_id>\d+)_(?P<observation_id_suffix>\d+)_wfi(?P<sca>\d+)_(?P<band>[A-Za-z0-9]+)_cal\.asdf",
+            re.IGNORECASE,
+        ),
+        # RickSims ASDF naming convention.
+        re.compile(
+            r"SNPIT_VISIT(?P<observation_id>\d+)_WFI(?P<sca>\d+)_(?P<band>[A-Za-z0-9]+)_L\d+\.asdf",
             re.IGNORECASE,
         ),
     ]


### PR DESCRIPTION
Update sidecar for version 2 of Kessler sims.

1. Update interpolate_over_bad_pixels to handle image and noise images more broadly, following @laldoroty 
2. Add example under SMDC for running on this second round of Kessler sims.
3. Update `_save_products_as_fits` to save the 16-bit float noise arrays defined in as the current L2 datamodel as 32-bit float for the debug FITS files (as the FITS standard does not support 16 bit floats).
4. Hack to get around not having an `observation_id`.  This could be taken out longer term.    In the meantime I've left a test in the SMDC examples directory as perhaps a reminder (?)